### PR TITLE
Change strict to safe for easier use in commonJS environments

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -174,7 +174,7 @@
 		"space-in-parens": [2, "always"],
 		"space-infix-ops": [2],
 		"space-unary-ops": [2],
-		"strict": [2, "function"],
+		"strict": [2, "safe"],
 		"use-isnan": [2],
 		"valid-jsdoc": [2],
 		"valid-typeof": [2],


### PR DESCRIPTION
Change the option rule from "function" to "safe" for use in CommonJS environments.
